### PR TITLE
Revisão da implementação da versão sequencial do map-reduce.

### DIFF
--- a/wordcount/data.go
+++ b/wordcount/data.go
@@ -7,7 +7,10 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+    "io"
 	"path/filepath"
+    "unicode"
+    "unicode/utf8"
 )
 
 const (
@@ -100,8 +103,82 @@ func splitData(fileName string, chunkSize int) (numMapFiles int, err error) {
 	/////////////////////////
 	// YOUR CODE GOES HERE //
 	/////////////////////////
-	numMapFiles = 0
+	
+    var (
+        file *os.File
+        fileInfo os.FileInfo
+    )
+    
+    if file, err = os.Open(fileName); err != nil {
+        log.Fatal(err)
+        return 0, err
+    }
+    
+    defer closeFile(file)
+
+    if fileInfo, err = file.Stat(); err != nil {
+        log.Fatal(err)
+        return 0, err
+    }
+
+    fileSize := fileInfo.Size()
+    
+    buffer := make([]byte, fileSize)
+    if _, err = file.Read(buffer); err!=nil && err!=io.EOF {
+        log.Fatal(err)
+        return 0, err
+    }
+    
+    numMapFiles = 0
+    minOffset := 0
+    maxOffset := 0
+    lastNotWordCharOffset := 0
+    
+    // IMPORTANT: This code already supports non-ascii texts;
+    for currOffset, char:=range string(buffer[:]) {
+        isWordChar := unicode.IsLetter(char) || unicode.IsNumber(char) // Word chars must be letters or numeric digits;
+        charSize := utf8.RuneLen(char) // In bytes;
+        if currOffset-minOffset+charSize>chunkSize { // Current char cannot be included;
+            maxOffset = currOffset
+            if isWordChar {
+                maxOffset = lastNotWordCharOffset
+            }
+            if err = createFile(mapFileName(numMapFiles), buffer[minOffset:maxOffset]); err!=nil {
+                log.Fatal(err)
+                return numMapFiles, err
+            }
+            numMapFiles++
+            minOffset = maxOffset
+        } else if !isWordChar {
+            lastNotWordCharOffset = currOffset+charSize
+        }
+    }
+    // Check reamining bytes;
+    if maxOffset<len(buffer) { // Last remaining bytes;
+        if err = createFile(mapFileName(numMapFiles), buffer[maxOffset:]); err!=nil {
+            log.Fatal(err)
+            return numMapFiles, err
+        }
+        numMapFiles++
+    }
+    
 	return numMapFiles, nil
+}
+
+func closeFile(file *os.File) {
+    file.Close()
+}
+
+func createFile(fileName string, data []byte) (err error) {
+    var file *os.File
+    if file, err = os.Create(fileName); err != nil {
+		return err
+	}
+    defer closeFile(file)
+    if _, err = file.Write(data); err != nil {
+		return err
+	}
+    return nil
 }
 
 func mapFileName(id int) string {

--- a/wordcount/wordcount.go
+++ b/wordcount/wordcount.go
@@ -3,6 +3,9 @@ package main
 import (
 	"github.com/pauloaguiar/ces27-lab1/mapreduce"
 	"hash/fnv"
+    "strings"
+    "unicode"
+    "strconv"
 )
 
 // mapFunc is called for each array of bytes read from the splitted files. For wordcount
@@ -26,6 +29,18 @@ func mapFunc(input []byte) (result []mapreduce.KeyValue) {
 	// YOUR CODE GOES HERE //
 	/////////////////////////
 	result = make([]mapreduce.KeyValue, 0)
+    if input!=nil && len(input)>0 {
+        wordsMap := make(map[string]int)
+        splitter := func(char rune) bool {
+            return !unicode.IsLetter(char) && !unicode.IsNumber(char)
+        }
+        for _, word:=range strings.FieldsFunc(strings.ToLower(string(input[:])), splitter) {
+            wordsMap[word] = wordsMap[word] + 1
+        }
+        for word, count:=range wordsMap {
+            result = append(result, mapreduce.KeyValue{Key:word, Value:strconv.Itoa(count)})
+        }
+    }
 	return result
 }
 
@@ -47,6 +62,17 @@ func reduceFunc(input []mapreduce.KeyValue) (result []mapreduce.KeyValue) {
 	// YOUR CODE GOES HERE //
 	/////////////////////////
 	result = make([]mapreduce.KeyValue, 0)
+    wordsMap := make(map[string]int)
+    for _, keyValue:=range input {
+        count, err := strconv.Atoi(keyValue.Value)
+        if(err!=nil) {
+            count = 1
+        }
+        wordsMap[keyValue.Key] = wordsMap[keyValue.Key] + count
+    }
+    for word, count:=range wordsMap {
+        result = append(result, mapreduce.KeyValue{Key:word, Value:strconv.Itoa(count)})
+    }
 	return result
 }
 


### PR DESCRIPTION
Boa tarde, Paulo.
Segue meu código referente ao lab 1 do map-reduce sequencial para sua revisão.
Destaco que minha implementação já permite o tratamento de textos unicode, ou seja, não se restringe apenas à textos ASCII.
Por favor, me envie seus comentários.
Abraços,

Ballock.
